### PR TITLE
Remove SyncPayload.resource with serialized form

### DIFF
--- a/p2p/src/main/java/com/google/android/fhir/p2p/SyncPayload.kt
+++ b/p2p/src/main/java/com/google/android/fhir/p2p/SyncPayload.kt
@@ -25,7 +25,7 @@ import org.hl7.fhir.r4.model.ResourceType
 data class SyncPayload(
   val resourceId: String,
   val resourceType: ResourceType,
-  val lastUpdatedDate: String,
+  val lastUpdateTimestamp: String,
   val serializedResource: String,
   /**
    * The list of changes which have been made to the resource since it was last updated from the

--- a/p2p/src/main/java/com/google/android/fhir/p2p/SyncPayload.kt
+++ b/p2p/src/main/java/com/google/android/fhir/p2p/SyncPayload.kt
@@ -16,22 +16,17 @@
 
 package com.google.android.fhir.p2p
 
-import ca.uhn.fhir.context.FhirContext
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
-import org.hl7.fhir.instance.model.api.IBaseResource
+import org.hl7.fhir.r4.model.ResourceType
 
 /** The payload for syncing changes between peers. */
 @Serializable
 data class SyncPayload(
-  /** The current version of the resource after all of the changes have been applied. */
-  @Serializable(with = FhirResourceSerializer::class) val resource: IBaseResource,
+  val resourceId: String,
+  val resourceType: ResourceType,
+  val lastUpdatedDate: String,
+  val serializedResource: String,
   /**
    * The list of changes which have been made to the resource since it was last updated from the
    * server.
@@ -48,15 +43,16 @@ sealed class RemoteChange {
   /** The creation of a new resource locally on the client. */
   @Serializable
   @SerialName("create")
-  data class Create(override val timestamp: String, val resource: String) : RemoteChange()
+  data class Create(
+    override val timestamp: String,
+    val resource: String
+  ) : RemoteChange()
 
   /** An update to a resource. */
   @Serializable
   @SerialName("update")
   data class Update(
     override val timestamp: String,
-    val resourceType: String,
-    val resourceId: String,
     val patch: String
   ) : RemoteChange()
 
@@ -64,17 +60,6 @@ sealed class RemoteChange {
   @Serializable
   @SerialName("delete")
   data class Delete(
-    override val timestamp: String,
-    val resourceType: String,
-    val resourceId: String
+    override val timestamp: String
   ) : RemoteChange()
-}
-
-private class FhirResourceSerializer : KSerializer<IBaseResource> {
-  override val descriptor: SerialDescriptor =
-    PrimitiveSerialDescriptor(IBaseResource::class.qualifiedName!!, PrimitiveKind.STRING)
-  override fun serialize(encoder: Encoder, value: IBaseResource) =
-    encoder.encodeString(FhirContext.forR4().newJsonParser().encodeResourceToString(value))
-  override fun deserialize(decoder: Decoder): IBaseResource =
-    FhirContext.forR4().newJsonParser().parseResource(decoder.decodeString())
 }

--- a/p2p/src/test/java/com/google/android/fhir/p2p/SyncPayloadTest.kt
+++ b/p2p/src/test/java/com/google/android/fhir/p2p/SyncPayloadTest.kt
@@ -34,7 +34,7 @@ class SyncPayloadTest {
   fun encodeToStringEncodesThePayloadToAJsonString() {
     val resourceId = "abc"
     val resourceType = ResourceType.Patient
-    val lastUpdatedDate = Instant.now().toString()
+    val lastUpdateTimestamp = Instant.now().toString()
     val resource = Patient().apply { id = resourceId }
     val serializedResource = FhirContext.forR4().newJsonParser().encodeResourceToString(resource)
     val patch = "[{\"op\":\"add\"}]"
@@ -47,7 +47,7 @@ class SyncPayloadTest {
         SyncPayload(
           resourceId,
           resourceType,
-          lastUpdatedDate,
+          lastUpdateTimestamp,
           serializedResource,
           listOf(
             RemoteChange.Create(createTimestamp, serializedResource),
@@ -59,7 +59,7 @@ class SyncPayloadTest {
 
     assertThat(encoded)
       .isEqualTo(
-        """{"resourceId":${Json.encodeToString(resourceId)},"resourceType":${Json.encodeToString(resourceType)},"lastUpdatedDate":${Json.encodeToString(lastUpdatedDate)},"serializedResource":${Json.encodeToString(serializedResource)},"changes":[{"type":"create","timestamp":${Json.encodeToString(createTimestamp)},"resource":${Json.encodeToString(serializedResource)}},{"type":"update","timestamp":${Json.encodeToString(updateTimestamp)},"patch":${Json.encodeToString(patch)}},{"type":"delete","timestamp":${Json.encodeToString(deleteTimestamp)}}]}"""
+        """{"resourceId":${Json.encodeToString(resourceId)},"resourceType":${Json.encodeToString(resourceType)},"lastUpdateTimestamp":${Json.encodeToString(lastUpdateTimestamp)},"serializedResource":${Json.encodeToString(serializedResource)},"changes":[{"type":"create","timestamp":${Json.encodeToString(createTimestamp)},"resource":${Json.encodeToString(serializedResource)}},{"type":"update","timestamp":${Json.encodeToString(updateTimestamp)},"patch":${Json.encodeToString(patch)}},{"type":"delete","timestamp":${Json.encodeToString(deleteTimestamp)}}]}"""
       )
   }
 
@@ -67,7 +67,7 @@ class SyncPayloadTest {
   fun decodeFromStringDecodesThePayloadFromAJsonString() {
     val resourceId = "abc"
     val resourceType = ResourceType.Patient
-    val lastUpdatedDate = Instant.now().toString()
+    val lastUpdateTimestamp = Instant.now().toString()
     val resource = Patient().apply { id = resourceId }
     val serializedResource = FhirContext.forR4().newJsonParser().encodeResourceToString(resource)
     val patch = "[{\"op\":\"add\"}]"
@@ -75,13 +75,13 @@ class SyncPayloadTest {
     val updateTimestamp = "2021-11-04"
     val deleteTimestamp = "2021-11-05"
     val payload =
-      """{"resourceId":${Json.encodeToString(resourceId)},"resourceType":${Json.encodeToString(resourceType)},"lastUpdatedDate":${Json.encodeToString(lastUpdatedDate)},"serializedResource":${Json.encodeToString(serializedResource)},"changes":[{"type":"create","timestamp":${Json.encodeToString(createTimestamp)},"resource":${Json.encodeToString(serializedResource)}},{"type":"update","timestamp":${Json.encodeToString(updateTimestamp)},"patch":${Json.encodeToString(patch)}},{"type":"delete","timestamp":${Json.encodeToString(deleteTimestamp)}}]}"""
+      """{"resourceId":${Json.encodeToString(resourceId)},"resourceType":${Json.encodeToString(resourceType)},"lastUpdateTimestamp":${Json.encodeToString(lastUpdateTimestamp)},"serializedResource":${Json.encodeToString(serializedResource)},"changes":[{"type":"create","timestamp":${Json.encodeToString(createTimestamp)},"resource":${Json.encodeToString(serializedResource)}},{"type":"update","timestamp":${Json.encodeToString(updateTimestamp)},"patch":${Json.encodeToString(patch)}},{"type":"delete","timestamp":${Json.encodeToString(deleteTimestamp)}}]}"""
 
     val decoded: SyncPayload = Json.decodeFromString(payload)
 
     assertThat(decoded.resourceId).isEqualTo(resourceId)
     assertThat(decoded.resourceType).isEqualTo(ResourceType.Patient)
-    assertThat(decoded.lastUpdatedDate).isEqualTo(lastUpdatedDate)
+    assertThat(decoded.lastUpdateTimestamp).isEqualTo(lastUpdateTimestamp)
     assertThat(decoded.serializedResource).isEqualTo(serializedResource)
     assertThat(decoded.changes)
       .isEqualTo(


### PR DESCRIPTION
I debated whether `resourceType` type should be `ResourceType` or `String`
The pros of `String` is that it does not bind the `SyncPayload` class to the R4 model, the cons are it is too generic.
The pros of `ResourceType` is that it does bind `SyncPayload` to the R4 model but is less generic.

Since the whole `engine` API is already bound to R4 I thought that the tradeoff of the additional dependency was worthwhile for the additional type safety.

Let me know what you think.